### PR TITLE
implement SetVolume command

### DIFF
--- a/examples/discovery_server.rs
+++ b/examples/discovery_server.rs
@@ -13,7 +13,7 @@
 use qonductor::{
     msg, ActivationState, BufferState, Command, DeviceConfig, DeviceSession, Notification,
     PlayingState, SessionEvent, SessionManager,
-    msg::{PositionExt, QueueRendererStateExt, SetStateExt, LoopModeSetExt},
+    msg::{PositionExt, QueueRendererStateExt, SetStateExt, LoopModeSetExt, report::VolumeChanged},
 };
 use serde::Deserialize;
 use std::fs;
@@ -66,6 +66,13 @@ async fn handle_device_events(device_name: String, mut session: DeviceSession) {
                         volume: 100,
                         max_quality: 4,
                         playback,
+                    });
+                }
+
+                Command::SetVolume { cmd, respond } => {
+                    println!("[{}] Volume changed: {:?}", device_name, cmd.volume);
+                    respond.send(VolumeChanged {
+                        volume: cmd.volume
                     });
                 }
 

--- a/examples/fake_player.rs
+++ b/examples/fake_player.rs
@@ -8,7 +8,7 @@
 use qonductor::{
     msg, ActivationState, BufferState, Command, DeviceConfig, LoopMode, Notification, PlayingState,
     SessionEvent, SessionManager,
-    msg::{PositionExt, QueueRendererStateExt, SetStateExt, LoopModeSetExt},
+    msg::{PositionExt, QueueRendererStateExt, SetStateExt, LoopModeSetExt, report::VolumeChanged},
 };
 use rand::{thread_rng, Rng};
 use serde::Deserialize;
@@ -264,6 +264,13 @@ impl FakePlayer {
         self.renderer_state()
     }
 
+    fn handle_set_volume(&mut self, volume: u32) -> VolumeChanged {
+        self.volume = volume;
+        VolumeChanged {
+            volume: Some(volume)
+        }
+    }
+
     fn handle_activate(&mut self) -> ActivationState {
         info!(renderer_id = self.renderer_id, "Device activated");
 
@@ -382,6 +389,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                         Command::SetActive { respond, .. } => {
                             let response = player.handle_activate();
+                            respond.send(response);
+                        }
+
+                        Command::SetVolume { cmd, respond } => {
+                            let response = player.handle_set_volume(cmd.volume.unwrap_or(100));
                             respond.send(response);
                         }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -7,6 +7,7 @@
 
 use tokio::sync::oneshot;
 
+use crate::msg::report::VolumeChanged;
 use crate::msg::{self, QueueRendererState};
 use crate::proto::qconnect::{QConnectMessage, QConnectMessageType};
 
@@ -131,6 +132,11 @@ pub enum Command {
     SetState {
         cmd: msg::cmd::SetState,
         respond: Responder<QueueRendererState>,
+    },
+
+    SetVolume {
+        cmd: msg::cmd::SetVolume,
+        respond: Responder<VolumeChanged>,
     },
 
     /// Device activation. Must respond with [`ActivationState`].

--- a/src/qconnect.rs
+++ b/src/qconnect.rs
@@ -474,6 +474,25 @@ impl SessionRunner {
                 }
             }
 
+            // SrvrRndrSetVolume (42) - Set volume
+            t if t == QConnectMessageType::MessageTypeSrvrRndrSetVolume as i32 => {
+                if let Some(ss) = msg.srvr_rndr_set_volume {
+                    let (tx, rx) = oneshot::channel();
+                    let _ = self
+                        .event_tx
+                        .send(SessionEvent::Command(Command::SetVolume {
+                            cmd: ss,
+                            respond: Responder::new(tx),
+                        }))
+                        .await;
+                    if let Ok(response) = rx.await
+                        && let Err(e) = self.do_report_volume(response.volume()).await
+                    {
+                        warn!(error = %e, "Failed to send playback response");
+                    }
+                }
+            }
+
             // SrvrRndrSetActive (43) - Server activates/deactivates us
             t if t == QConnectMessageType::MessageTypeSrvrRndrSetActive as i32 => {
                 if let Some(sa) = msg.srvr_rndr_set_active {


### PR DESCRIPTION
Messages received and sent to server for a volume changed:

```
RX: SrvrRndrSetVolume { volume: Some(57), volume_delta: None }
TX: RndrSrvrVolumeChanged { volume: Some(57) }
```

This is a breaking change for downstream clients as they now have to implement `Command::SetVolume`